### PR TITLE
Amended: Encode function argument typings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ esm/jwt.js
 cjs_src/
 debug/
 lib/
+.prettierignore

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nats-io/jwt",
-  "version": "0.0.10-9",
+  "version": "0.0.10-8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nats-io/jwt",
-      "version": "0.0.10-9",
+      "version": "0.0.10-8",
       "license": "Apache-2.0",
       "dependencies": {
         "@nats-io/nkeys": "2.0.0-4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nats-io/jwt",
-  "version": "0.0.10-8",
+  "version": "0.0.10-9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nats-io/jwt",
-      "version": "0.0.10-8",
+      "version": "0.0.10-9",
       "license": "Apache-2.0",
       "dependencies": {
         "@nats-io/nkeys": "2.0.0-4"

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -74,7 +74,7 @@ function initAlgorithm(opts: Partial<EncodingOptions> = {}): EncodingOptions {
  */
 export async function encodeOperator(
   name: string,
-  okp: Key,
+  okp: Key | string,
   operator: Partial<Operator> = {},
   opts: Partial<EncodingOptions> = {},
 ): Promise<string> {
@@ -102,7 +102,7 @@ export async function encodeOperator(
  */
 export async function encodeAccount(
   name: string,
-  akp: Key,
+  akp: Key | string,
   account: Partial<Account> = {},
   opts: Partial<EncodingOptions> = {},
 ): Promise<string> {
@@ -122,8 +122,8 @@ export async function encodeAccount(
 
 export async function encodeUser(
   name: string,
-  ukp: Key,
-  issuer: Key,
+  ukp: Key | string,
+  issuer: Key | string,
   user: Partial<User> = {},
   opts: Partial<UserEncodingOptions> = {},
 ): Promise<string> {
@@ -147,8 +147,8 @@ export async function encodeUser(
 
 export function encodeActivation(
   name: string,
-  subject: Key,
-  issuer: Key,
+  subject: Key | string,
+  issuer: Key | string,
   kind: "service" | "stream",
   data: Partial<Activation> = {},
   opts: Partial<EncodingOptions> = {},
@@ -175,7 +175,7 @@ export function encodeActivation(
 
 export async function encodeGeneric(
   name: string,
-  akp: Key,
+  akp: Key | string,
   kind: string,
   data: Partial<Generic> = {},
   opts: Partial<EncodingOptions> = {},
@@ -199,9 +199,9 @@ export async function encodeGeneric(
 }
 
 export async function encodeAuthorizationResponse(
-  user: Key,
-  server: Key,
-  issuer: Key,
+  user: Key | string,
+  server: Key | string,
+  issuer: Key | string,
   data: Partial<AuthorizationResponse>,
   opts: Partial<EncodingOptions>,
 ): Promise<string> {


### PR DESCRIPTION
The 'encode' functions accept key arguments that can be provided as Keys or strings - this PR amends the typings to indicate strings are permitted.